### PR TITLE
Dev environment setup + mobile player control alignment fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Luscreen is a **client-only Angular 19 SPA** (media streaming/discovery UI). There is no backend, database, or container in this repo — all data comes from external third-party APIs called directly from the browser (TMDB for metadata/images, VidFast for player embeds, Google Gemini for the AI recommendation page, and PeerJS's public broker for the Watch Party feature). **Internet access is required** for the app to show any content. API keys are hardcoded in `src/environments/environment.ts` and a few components, so no secrets/`.env` setup is needed.
+
+### Services
+
+Only one local service: the Angular dev server. Standard commands are in `package.json` and `README.md`; the notable ones:
+- Run dev server: `npm start` (i.e. `ng serve`, http://localhost:4200). Component HMR is enabled by default.
+- Dev build: `npm run build -- --configuration development` (the default `npm run build` uses the `production` config, which enforces bundle budgets).
+
+### Testing / lint caveats
+- **No lint is configured** — there is no `lint` script, no `lint` target in `angular.json`, and no ESLint config. Do not expect `ng lint` to work.
+- `npm test` (`ng test`) uses Karma + Jasmine and needs a Chrome binary. In this headless VM run it with:
+  `CHROME_BIN=$(which google-chrome) npx ng test --watch=false --browsers=ChromeHeadless`
+- The 4 scaffolded spec files (`app.component.spec.ts`, `home`, `frame`, `ai`) currently **fail out of the box** (missing `ActivatedRoute`/`HttpClient` providers in the specs). These are pre-existing test bugs, not an environment problem — the Karma runner itself works.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6581,6 +6581,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6594,6 +6595,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6607,6 +6609,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6620,6 +6623,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6633,6 +6637,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6646,6 +6651,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6659,6 +6665,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6672,6 +6679,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6685,6 +6693,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6698,6 +6707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6711,6 +6721,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6724,6 +6735,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6737,6 +6749,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6750,6 +6763,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6763,6 +6777,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6776,6 +6791,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6789,6 +6805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6802,6 +6819,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6815,6 +6833,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/app/components/frame/frame.component.html
+++ b/src/app/components/frame/frame.component.html
@@ -211,9 +211,12 @@
             </div>
 
             <!-- Control buttons (hidden in fullscreen until chevron is tapped) -->
-            <div *ngIf="showPlayerButtons" class="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-1">
+            <div *ngIf="showPlayerButtons" class="flex flex-col gap-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] sm:items-center sm:gap-1">
               <!-- Left: episode nav (balances the right side) -->
-              <div class="flex items-center justify-start gap-0.5 sm:gap-1 min-h-[40px]">
+              <div
+                class="items-center justify-center sm:justify-start gap-0.5 sm:gap-1 sm:min-h-[40px]"
+                [ngClass]="mediaType === 'tv' ? 'flex' : 'hidden sm:flex'"
+              >
                 <button
                   *ngIf="mediaType === 'tv'"
                   type="button"
@@ -280,7 +283,7 @@
               </div>
 
               <!-- Right: cc + server + sync + fullscreen -->
-              <div class="flex items-center justify-end gap-1 flex-wrap">
+              <div class="flex items-center justify-center sm:justify-end gap-1 flex-wrap">
                 <!-- CC / subtitles -->
                 <div class="relative">
                   <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two logical changes on this branch:

1. **Dev environment setup** — added `AGENTS.md` (`## Cursor Cloud specific instructions`) documenting the client-only Angular 19 SPA, run/build/test commands, and caveats (no lint configured, internet required, pre-existing failing scaffolded specs). Update script configured as `npm install`.
2. **Mobile player control alignment fix** (`src/app/components/frame/frame.component.html`) — on narrow (mobile) viewports the player's custom control buttons were laid out with a rigid 3-column grid (`grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]`), so the right-side buttons (CC/Server/PiP/Fullscreen) wrapped chaotically and the center play group looked off-center. The row now stacks into clean, centered rows on mobile while keeping the original single-row grid at `sm:` and up (desktop unchanged, non-fullscreen only).

## Mobile control alignment — before / after

[Before: mobile controls scattered/misaligned](https://cursor.com/agents/bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fframe_mobile_controls_before.webp)
[After: mobile controls aligned in centered rows](https://cursor.com/agents/bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fframe_mobile_controls_after.webp)

Demo (mobile viewport, controls aligned + CC dropdown interaction):

[frame_mobile_controls_aligned_demo.mp4](https://cursor.com/agents/bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fframe_mobile_controls_aligned_demo.mp4)

Desktop layout unchanged (still a single row):

[Desktop controls unchanged](https://cursor.com/agents/bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fframe_desktop_controls_unchanged.webp)

## Environment verification

| Step | Command | Result |
|---|---|---|
| Install | `npm install` | pass |
| Dev build | `npm run build -- --configuration development` | pass |
| Tests | `CHROME_BIN=$(which google-chrome) npx ng test --watch=false --browsers=ChromeHeadless` | runner works; 6 pre-existing spec failures |
| Dev server | `npm start` (`ng serve`, :4200) | pass (HTTP 200) |
| Lint | n/a | not configured in this repo |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47c4feb2-8b21-4170-9f4c-6eeaf71127e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

