### PR TITLE
Fix session wipe after auth API cold start

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable, catchError, map, of, tap, timeout } from 'rxjs';
+import { Observable, catchError, map, of, retry, tap, throwError, timeout, timer } from 'rxjs';
 import { environment } from '../../environments/environment';
 
 export interface AuthUser {
@@ -128,7 +128,8 @@ export class AuthService {
         headers: new HttpHeaders({ Authorization: `Bearer ${token}` }),
       })
       .pipe(
-        timeout(20000),
+        // Render free tier cold starts often need >20s; retries cover the rest.
+        timeout(25000),
         map((res) => {
           this.userSignal.set(res.user);
           try {
@@ -138,8 +139,24 @@ export class AuthService {
           }
           return res.user;
         }),
-        catchError(() => {
-          this.logout();
+        retry({
+          count: 2,
+          delay: (error, retryCount) => {
+            // Never retry a rejected credential — surface 401 immediately.
+            if (this.isUnauthorizedError(error)) {
+              return throwError(() => error);
+            }
+            // Backoff while the auth API wakes up (e.g. after ~1hr idle).
+            const waitMs = retryCount === 1 ? 2000 : 5000;
+            return timer(waitMs);
+          },
+        }),
+        catchError((err) => {
+          // Only clear the local session when the server rejects the token.
+          // Timeouts / network / 5xx keep the cached login so cold starts don't log users out.
+          if (this.isUnauthorizedError(err)) {
+            this.logout();
+          }
           return of(null);
         })
       );
@@ -247,6 +264,11 @@ export class AuthService {
     } catch {
       return null;
     }
+  }
+
+  /** True when the auth API rejected the credential (not a cold-start / network blip). */
+  private isUnauthorizedError(err: unknown): boolean {
+    return (err as { status?: number })?.status === 401;
   }
 
   private toError(err: unknown, fallback: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
After leaving Luscreens idle (~1 hour), returning to the site logged users out even though their JWT was still valid.

On every load, `AuthService.refreshMe()` calls `/auth/me`. Any failure — including Render free-tier cold-start timeouts — called `logout()` and cleared `localStorage`.

## Fix
In `src/app/services/auth.service.ts`:
- **Only logout on HTTP 401** (invalid/expired token or user not found)
- **Keep the cached session** on timeouts, network errors, and 5xx
- **Retry** transient failures twice with backoff (2s, then 5s) while the auth API wakes up
- Slightly raise the per-attempt timeout to 25s

Expired/invalid tokens still log the user out correctly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-464c232e-9886-4775-b3ed-238d6e8e22fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464c232e-9886-4775-b3ed-238d6e8e22fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

